### PR TITLE
Make GitHub detect *.opf as Forth

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.opf linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect your `.opf` files as Forth.

Thanks!
